### PR TITLE
Respect policy list expiration

### DIFF
--- a/starttls_policy/tests/configure_test.py
+++ b/starttls_policy/tests/configure_test.py
@@ -1,8 +1,9 @@
 """ Tests for configure.py """
 
 import unittest
+import tempfile
+import os
 
-import json
 import mock
 
 from starttls_policy import configure
@@ -12,6 +13,9 @@ class MockGenerator(configure.ConfigGenerator):
 
     def _generate(self, policy_list):
         return "generated_config"
+
+    def _generate_expired_fallback(self, policy_list):
+        return "#expired_fallback"
 
     def _instruct_string(self):
         return "instruct_string"
@@ -44,7 +48,41 @@ class TestConfigGenerator(unittest.TestCase):
                 "instruct_string")
 
 
+class TempPolicyDir(object):
+    # pylint: disable=useless-object-inheritance,attribute-defined-outside-init
+    """This context manager creates temporary directory
+    and writes given policy into it."""
+    def __init__(self, conf):
+        self._conf = conf
+
+    def __enter__(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._policy_filename = os.path.join(self._tmpdir, 'policy.json')
+        with open(self._policy_filename, 'w') as pol_file:
+            pol_file.write(self._conf)
+        return self._tmpdir
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.remove(self._policy_filename)
+        os.rmdir(self._tmpdir)
+
 test_json = '{\
+    "author": "Electronic Frontier Foundation",\
+    "timestamp": "2018-06-18T09:41:50.264201364-07:00",\
+    "expires": "2038-01-16T09:41:50.264201364-07:00",\
+        "policies": {\
+            ".valid.example-recipient.com": {\
+                "mode": "enforce",\
+                "mxs": [".valid.example-recipient.com"]\
+            },\
+            ".testing.example-recipient.com": {\
+                "mode": "testing",\
+                "mxs": [".testing.example-recipient.com"]\
+            }\
+        }\
+    }'
+
+test_json_expired = '{\
     "author": "Electronic Frontier Foundation",\
     "timestamp": "2018-06-18T09:41:50.264201364-07:00",\
     "expires": "2018-07-16T09:41:50.264201364-07:00",\
@@ -60,19 +98,17 @@ test_json = '{\
         }\
     }'
 
+testgen_data = [
+    ("simple_policy", test_json, "# .testing.example-recipient.com "
+                                 "undefined due to testing policy\n"
+                                 ".valid.example-recipient.com    "
+                                 "secure match=.valid.example-recipient.com\n"),
+    ("expired_policy", test_json_expired, "# Policy list is outdated. "
+                                          "Falling back to opportunistic encryption.\n"),
+]
+
 class TestPostfixGenerator(unittest.TestCase):
     """Test Postfix config generator"""
-
-    def test_generate(self):
-        from starttls_policy import policy
-        conf = policy.Config()
-        conf.load_from_dict(json.loads(test_json))
-        generator = configure.PostfixGenerator("./")
-        result = generator._generate(conf) # pylint: disable=protected-access
-        self.assertEqual(result, "# .testing.example-recipient.com "
-                         "undefined due to testing policy\n"
-                         ".valid.example-recipient.com    "
-                         "secure match=.valid.example-recipient.com")
 
     def test_mta_name(self):
         generator = configure.PostfixGenerator("./")
@@ -85,6 +121,25 @@ class TestPostfixGenerator(unittest.TestCase):
         self.assertTrue("postconf -e \"smtp_tls_policy_maps=" in instructions)
         self.assertTrue("postfix reload" in instructions)
         self.assertTrue(generator.default_filename in instructions)
+
+def enclose_config_case(conf, expected):
+    """Wrap testcase against config into closure in order to make it attachable
+    to main testcase class"""
+    def test(self):
+        with TempPolicyDir(conf) as testdir:
+            generator = configure.PostfixGenerator(testdir)
+            generator.generate()
+            pol_filename = os.path.join(testdir, generator.default_filename)
+            with open(pol_filename) as pol_file:
+                result = pol_file.read()
+            os.remove(pol_filename)
+        self.assertEqual(result, expected)
+    return test
+
+for tname, a, b in testgen_data:
+    test_name = "test_%s" % tname
+    wrapped_test = enclose_config_case(a, b)
+    setattr(TestPostfixGenerator, test_name, wrapped_test)
 
 if __name__ == "__main__":
     unittest.main()

--- a/starttls_policy/util.py
+++ b/starttls_policy/util.py
@@ -3,7 +3,7 @@
 import datetime
 from functools import partial
 import six
-from dateutil import parser # Dependency: python-dateutil
+from dateutil import parser, tz # Dependency: python-dateutil
 
 
 class ConfigError(ValueError):
@@ -66,6 +66,10 @@ def parse_valid_date(date):
         return parser.parse(date)
     except (TypeError, ValueError):
         raise ConfigError("Invalid date: {}".format(date))
+
+def is_expired(exp):
+    """ Checks if given expiration datetime is reached at this moment. """
+    return exp <= datetime.datetime.now(tz.tzutc())
 
 def get_properties(schema):
     """ Return the three properties we have to enforce for this schema.


### PR DESCRIPTION
This pull request contains changes discussed in [PR in old repo](https://github.com/EFForg/starttls-everywhere/pull/87).

Here is excerpt from old discussion about unresolved questions to new code.

## About mocking FS IO

> Instead of actually writing to policy.json, it may be cleaner to use mock.mock_open to mock all the open calls.

> What do you think about mocking the open methods rather than writing these files to /tmp?

`mock` is a great tool, but I doubt about it's purpose here. Mocking actual file IO allows us to run tests clearly, without interacting with real FS. But creation of temporary directory with file is not something we can't afford.

In general, best practice is to mock as less as possible, resort to mock only when counterpart our code tested against cannot be efficiently represented by real instance.

Mock solution has following benefit over real FS write: it avoids usage of real FS. But it has drawbacks:
* Reader will **always** read `read_data` with same type of string `mock_open` was initialized. Consider [following examples](https://gist.github.com/Snawoot/33b797bad8265a78f1071626d41de559). So, `mock_open` is imperfect.
* Reading of file by a program may produce different results depending on method of reading. For example, there are no reasons why `policy.json` can't have byte order mark in the beginning of file and to handle such case we have to use special BOM-aware codec. Mocked file defined by a string doesn't allow us to conduct tests against real files.
* Mocking requires test to have some knowledge of internal structure of program in order it can be properly patched, and this knowledge has to be maintained. What if we will use some faster json module which will load json file directly?

BTW, when our project will become popular (I believe!) and policy list will be big enough to not fit in memory, we probably will have to reconsider parsing of json file anyway in order to reduce memory footprint required to generate policy. Maybe generator-like json parser like `ijson` will do.

I think if we will need to mock file IO, we can return to it in future. But for now it is unnecessary.

## About tests generation



> Generating these tests dynamically is nice, but could be opaque-- for instance, if a particular test fails here, it may be difficult for someone unfamiliar with the project to trace back where the failure occurred.
> 
> What do you think about having a single test_generate that instead loops over the test cases and performs each one?


If I make some test fail (for example, by modifying expected result) it will clearly indicate which test has failed, like this:
```
...
=================================== FAILURES ===================================
___________________ TestPostfixGenerator.test_expired_policy ___________________
...
```

All testcases in test matrix have ID (first element in tuple). This ID is used to generate test name when it is added to `TestPostfixGenerator`. Its commonly established practice and below I'll provide some details about reasons.

I've considered many options when I was seeking for solution. Most obvious way and common practice is to use `@pytest.mark.parametrize` decorator. This decorator accepts matrix for test cases which optionally marked by ID used to infer test name. But I rejected this solution because:
* Current tests doesn't depend on pytest (but can be run with it). So I had to stick to `unittest` API in order to retain current independence from external testing framework.
* Single method `unittest.TestCase` cannot be parameterized because it can accept only one parameter with class instance by definition of its interface.

Considering ways which are compatible with `unittest` there are few options:
1. Use external package `parameterized` which provides decorator doing essentially same thing I do now, but adds external dependency.
2. Simply add test methods linked to testcases via closure in simple loop. (Actual implementation)
3. Use metaclasses and other complicated mechanisms in order to do job similar to option 2.

Solution with single test function iterating over config matrix is tempting, but I didn't chose it because it is not transparent to test runner:
1. All configs are collected by test runner as a single test. In my implementation it is distinct named tests.
2. For this reason it is not possible to enumerate tests properly (like `pytest --collect-only`) or run specific config test without running all other config tests. My implementation allows it. Example: `pytest tests/configure_test.py::TestPostfixGenerator::test_simple_policy`
3. External tools for building automated test reports (like Allure) will not be able to produce proper output about found defects.

In other words, this solution is somewhat simpliest way to parameterize tests, preserving proper testcase semantics and compatibility with built-in `unittest` library.