### PR TITLE
Respect policy list expiration

### DIFF
--- a/starttls_policy/tests/configure_test.py
+++ b/starttls_policy/tests/configure_test.py
@@ -1,17 +1,22 @@
 """ Tests for configure.py """
 
 import unittest
+import tempfile
+import os
 
-import json
 import mock
 
 from starttls_policy import configure
+from starttls_policy.tests.util import param, parametrize_over
 
 class MockGenerator(configure.ConfigGenerator):
     """Mock config generator for testing"""
 
     def _generate(self, policy_list):
         return "generated_config"
+
+    def _generate_expired_fallback(self, policy_list):
+        return "#expired_fallback"
 
     def _instruct_string(self):
         return "instruct_string"
@@ -27,24 +32,62 @@ class MockGenerator(configure.ConfigGenerator):
 class TestConfigGenerator(unittest.TestCase):
     """Test the base config generator class"""
     def test_generate(self):
-        generator = MockGenerator("./")
-        with mock.patch("starttls_policy.configure.open", mock.mock_open()) as m:
+        with TempPolicyDir(test_json) as testdir:
+            generator = MockGenerator(testdir)
             generator.generate()
-            m().write.assert_any_call("generated_config")
-            m().write.assert_any_call("\n")
+            pol_filename = os.path.join(testdir, generator.default_filename)
+            with open(pol_filename) as pol_file:
+                result = pol_file.read()
+            os.remove(pol_filename)
+        self.assertEqual(result, "generated_config\n")
 
     def test_manual_instructions(self):
-        generator = MockGenerator("./")
-        with mock.patch("starttls_policy.configure.six.print_") as mock_print:
-            generator.manual_instructions()
-            mock_print.assert_called_once_with("\n"
-                "--------------------------------------------------\n"
-                "Manual installation instructions for fake\n"
-                "--------------------------------------------------\n"
-                "instruct_string")
+        with TempPolicyDir(test_json) as testdir:
+            generator = MockGenerator(testdir)
+            with mock.patch("starttls_policy.configure.six.print_") as mock_print:
+                generator.manual_instructions()
+                mock_print.assert_called_once_with("\n"
+                    "--------------------------------------------------\n"
+                    "Manual installation instructions for fake\n"
+                    "--------------------------------------------------\n"
+                    "instruct_string")
 
+
+class TempPolicyDir(object):
+    # pylint: disable=useless-object-inheritance,attribute-defined-outside-init
+    """This context manager creates temporary directory
+    and writes given policy into it."""
+    def __init__(self, conf):
+        self._conf = conf
+
+    def __enter__(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._policy_filename = os.path.join(self._tmpdir, 'policy.json')
+        with open(self._policy_filename, 'w') as pol_file:
+            pol_file.write(self._conf)
+        return self._tmpdir
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.remove(self._policy_filename)
+        os.rmdir(self._tmpdir)
 
 test_json = '{\
+    "author": "Electronic Frontier Foundation",\
+    "timestamp": "2018-06-18T09:41:50.264201364-07:00",\
+    "expires": "2038-01-16T09:41:50.264201364-07:00",\
+        "policies": {\
+            ".valid.example-recipient.com": {\
+                "mode": "enforce",\
+                "mxs": [".valid.example-recipient.com"]\
+            },\
+            ".testing.example-recipient.com": {\
+                "mode": "testing",\
+                "mxs": [".testing.example-recipient.com"]\
+            }\
+        }\
+    }'
+
+test_json_expired = '{\
     "author": "Electronic Frontier Foundation",\
     "timestamp": "2018-06-18T09:41:50.264201364-07:00",\
     "expires": "2018-07-16T09:41:50.264201364-07:00",\
@@ -60,19 +103,17 @@ test_json = '{\
         }\
     }'
 
+testgen_data = [
+    param("simple_policy", test_json, "# .testing.example-recipient.com "
+                                      "undefined due to testing policy\n"
+                                      ".valid.example-recipient.com    "
+                                      "secure match=.valid.example-recipient.com\n"),
+    param("expired_policy", test_json_expired, "# Policy list is outdated. "
+                                               "Falling back to opportunistic encryption.\n"),
+]
+
 class TestPostfixGenerator(unittest.TestCase):
     """Test Postfix config generator"""
-
-    def test_generate(self):
-        from starttls_policy import policy
-        conf = policy.Config()
-        conf.load_from_dict(json.loads(test_json))
-        generator = configure.PostfixGenerator("./")
-        result = generator._generate(conf) # pylint: disable=protected-access
-        self.assertEqual(result, "# .testing.example-recipient.com "
-                         "undefined due to testing policy\n"
-                         ".valid.example-recipient.com    "
-                         "secure match=.valid.example-recipient.com")
 
     def test_mta_name(self):
         generator = configure.PostfixGenerator("./")
@@ -85,6 +126,19 @@ class TestPostfixGenerator(unittest.TestCase):
         self.assertTrue("postconf -e \"smtp_tls_policy_maps=" in instructions)
         self.assertTrue("postfix reload" in instructions)
         self.assertTrue(generator.default_filename in instructions)
+
+    def config_test(self, conf, expected):
+        """PostfixGenerator test parameterized over various policies"""
+        with TempPolicyDir(conf) as testdir:
+            generator = configure.PostfixGenerator(testdir)
+            generator.generate()
+            pol_filename = os.path.join(testdir, generator.default_filename)
+            with open(pol_filename) as pol_file:
+                result = pol_file.read()
+            os.remove(pol_filename)
+        self.assertEqual(result, expected)
+
+parametrize_over(TestPostfixGenerator, TestPostfixGenerator.config_test, testgen_data)
 
 if __name__ == "__main__":
     unittest.main()

--- a/starttls_policy/tests/util.py
+++ b/starttls_policy/tests/util.py
@@ -1,0 +1,29 @@
+"""Various utils used by tests"""
+
+import collections
+
+ParamSet = collections.namedtuple('ParamSet', ('id', 'args', 'kwargs'))
+
+def param(test_name, *args, **kwargs):
+    """Convenient wrapper to ParamSet constructor for inline usage in dataset definition."""
+    return ParamSet(test_name, args, kwargs)
+
+def parametrize_over(cls, test, data):
+    """Iterates over dataset and adds test for each combination of params
+
+    Args:
+        cls: TestCase class where tests will be attached.
+        test: method of TestCase to parametrize.
+        data: List of ParamSet objects, one for each test run.
+
+    Returns:
+        None
+
+    """
+    for entry in data:
+        test_name = "test_" + entry.id
+        def _partial(func, *args, **kwargs):
+            def wrapped(self):
+                return func(self, *args, **kwargs)
+            return wrapped
+        setattr(cls, test_name, _partial(test, *entry.args, **entry.kwargs))

--- a/starttls_policy/util.py
+++ b/starttls_policy/util.py
@@ -3,7 +3,7 @@
 import datetime
 from functools import partial
 import six
-from dateutil import parser # Dependency: python-dateutil
+from dateutil import parser, tz # Dependency: python-dateutil
 
 
 class ConfigError(ValueError):
@@ -66,6 +66,10 @@ def parse_valid_date(date):
         return parser.parse(date)
     except (TypeError, ValueError):
         raise ConfigError("Invalid date: {}".format(date))
+
+def is_expired(exp):
+    """ Checks if given expiration datetime is reached at this moment. """
+    return exp <= datetime.datetime.now(tz.tzutc())
 
 def get_properties(schema):
     """ Return the three properties we have to enforce for this schema.


### PR DESCRIPTION
New pull request since I can't change branch content in not mine repo (and can't change PR source branch either).

Changes since last attempt:
* Tests for parent generator class also are wrapped by context manager introduced by previous versions of this PR. It resolves dependency of test on policy.json file in repo.
* Parameterizing code now is common test util (and quite easy to use I hope). So it is not related only to config tests and I used general naming.
* Naming improved

Signed-off-by: Vladislav Yarmak <vladislav@vm-0.com>