### PR TITLE
util: fix parse_valid_date; util, policy: improve test coverage

### DIFF
--- a/starttls_policy_cli/tests/util.py
+++ b/starttls_policy_cli/tests/util.py
@@ -27,3 +27,12 @@ def parametrize_over(cls, test, data):
                 return func(self, *args, **kwargs)
             return wrapped
         setattr(cls, test_name, _partial(test, *entry.args, **entry.kwargs))
+
+def assertRaisesRegex(testcase, exc, regex):
+    """Portable wrapper for method unittest.TestCase.assertRaisesRegexp which was
+    renamed to assertRaisesRegexp in Python 3"""
+    try:
+        meth = testcase.assertRaisesRegex
+    except AttributeError:
+        meth = testcase.assertRaisesRegexp
+    return meth(exc, regex)

--- a/starttls_policy_cli/tests/util_test.py
+++ b/starttls_policy_cli/tests/util_test.py
@@ -1,8 +1,11 @@
 """ Tests for util.py """
 import unittest
 from functools import partial
+import datetime
+from dateutil import tz
 
 from starttls_policy_cli import util
+from starttls_policy_cli.tests.util import param, parametrize_over
 
 class TestEnforceUtil(unittest.TestCase):
     """ Unittests for "enforcer" functions."""
@@ -40,6 +43,37 @@ class TestEnforceUtil(unittest.TestCase):
 
     def test_parse_bad_datestring(self):
         self.assertRaises(util.ConfigError, util.parse_valid_date, "fake")
+
+    def parse_valid_date_test(self, valid_date, expected):
+        """Parametrized test for util.parse_valid_date function"""
+        self.assertEqual(util.parse_valid_date(valid_date), expected)
+
+    def is_expired_test(self, expiration, expected):
+        """Parametrized test for util.is_expired function"""
+        self.assertEqual(util.is_expired(expiration), expected)
+
+parametrize_over(TestEnforceUtil, TestEnforceUtil.parse_valid_date_test,
+                 [
+                    param("valid_datetime_date",
+                          datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tz.tzutc()),
+                          datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tz.tzutc())),
+                    param("valid_integer_date",
+                          0,
+                          datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tz.tzutc())),
+                    param("valid_string_date",
+                          "2014-05-26T01:35:33+00:00",
+                          datetime.datetime(2014, 5, 26, 1, 35, 33, tzinfo=tz.tzutc())),
+                 ])
+
+parametrize_over(TestEnforceUtil, TestEnforceUtil.is_expired_test,
+                 [
+                    param("expired",
+                          datetime.datetime(1970, 1, 1, 0, 0, tzinfo=tz.tzutc()),
+                          True),
+                    param("nonexpired",
+                          datetime.datetime(2038, 1, 1, 0, 0, tzinfo=tz.tzutc()),
+                          False),
+                 ])
 
 if __name__ == '__main__':
     unittest.main()

--- a/starttls_policy_cli/util.py
+++ b/starttls_policy_cli/util.py
@@ -61,7 +61,7 @@ def parse_valid_date(date):
     if isinstance(date, datetime.datetime):
         return date
     if isinstance(date, int):
-        return datetime.datetime.fromtimestamp(date)
+        return datetime.datetime.fromtimestamp(date, tz.tzutc())
     try: # Fallback: try to parse a string-like
         return parser.parse(date)
     except (TypeError, ValueError):

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ basepython = python2.7
 commands =
     pip install -e ".[dev]"
     pytest --cov . --cov-append --cov-report= .
-    coverage report --fail-under=96 --include="starttls_policy_cli/*" --omit="*/tests*" --show-missing
+    coverage report --fail-under=99 --include="starttls_policy_cli/*" --omit="*/tests*" --show-missing


### PR DESCRIPTION
Changes:
* Fixes `util.parse_valid_date`: before it was returning TZ-unaware result depending on local timezone.
* Allows config merge between subclasses of MergableConfig.
* Adds test utility function for portable `assertRaisesRegex` assertion.
* Improves test coverage: now only two lines in main file are not covered by tests.