### PR TITLE
Make testdata compliant with spec

### DIFF
--- a/starttls_policy_cli/tests/testdata/bigger_test_config.json
+++ b/starttls_policy_cli/tests/testdata/bigger_test_config.json
@@ -1,23 +1,23 @@
 {
+  "version": "0.1",
   "author": "Electronic Frontier Foundation https://eff.org",
   "expires": "2015-08-01T12:00:00+08:00",
   "timestamp": 1401414363,
-  "tls-policies": {
-    ".yahoodns.net": {
+  "pinsets": {},
+  "policy-aliases": {},
+  "policies": {
+    "yahoodns.net": {
       "mode": "testing",
-      "mxs": [".yahoodns.net"],
-      "require-valid-certificate": true
+      "mxs": [".yahoodns.net"]
     },
-    ".eff.org": {
+    "eff.org": {
       "mode": "enforce",
-      "min-tls-version": "TLSv1.1",
-      "require-valid-certificate": true
+      "mxs": [".eff.org"]
     },
-    ".google.com": {
-      "require-valid-certificate": true,
-      "min-tls-version": "TLSv1.1",
+    "google.com": {
       "mode": "testing",
-      "tls-report": "https://google.com/post/reports/here"
+      "mxs": [".google.com"],
+      "report": ["https://google.com/post/reports/here"]
     }
   }
 }

--- a/starttls_policy_cli/tests/testdata/config.json
+++ b/starttls_policy_cli/tests/testdata/config.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.1",
   "timestamp": "2014-06-06T14:30:16+00:00",
   "author": "Electronic Frontier Foundation https://eff.org",
   "expires": "2014-06-06T14:30:16+00:00",
@@ -13,7 +14,7 @@
   "policy-aliases": {
     "gmail": {
       "mode": "testing",
-      "report-uris": ["https://google.com/post/reports/here"],
+      "report": ["https://google.com/post/reports/here"],
       "mxs": [".mail.google.com"]
     }
   },

--- a/starttls_policy_cli/tests/testdata/utf8.json
+++ b/starttls_policy_cli/tests/testdata/utf8.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1",
-    "author": "電子前沿基金會",
+    "author": "电子前哨基金会",
     "expires": 1404677353,
     "timestamp": 1401093333,
     "pinsets": {},

--- a/starttls_policy_cli/tests/testdata/utf8.json
+++ b/starttls_policy_cli/tests/testdata/utf8.json
@@ -1,7 +1,9 @@
 {
-    "author": "Electronic Frontier Foundation",
-    "comment": "你好世界",
+    "version": "0.1",
+    "author": "電子前沿基金會",
     "expires": 1404677353,
     "timestamp": 1401093333,
-    "tls-policies": {}
+    "pinsets": {},
+    "policy-aliases": {},
+    "policies": {}
 }


### PR DESCRIPTION
It seems testdata was composed for old version of policy format and outdated. Now it validates successfully against [schema for current format](https://gist.github.com/Snawoot/4726af7aca856aa058a4a5939d086cfc).