### PR TITLE
relax timezone parsing

### DIFF
--- a/starttls_policy_cli/tests/policy_test.py
+++ b/starttls_policy_cli/tests/policy_test.py
@@ -12,8 +12,8 @@ from starttls_policy_cli.tests.util import assertRaisesRegex, param, parametrize
 
 test_json = '{\
     "author": "Electronic Frontier Foundation",\
-        "expires": "2014-05-26T01:35:33",\
-        "timestamp": "2014-05-26T01:35:33",\
+        "expires": "2014-05-26T01:35:33+0000",\
+        "timestamp": "2014-05-26T01:35:33+0000",\
         "policies": {\
             ".valid.example-recipient.com": {\
                 "min-tls-version": "TLSv1.1",\
@@ -50,6 +50,8 @@ class TestConfig(unittest.TestCase):
     # pylint: disable=too-many-public-methods
     """Testing configuration
     """
+
+    maxDiff = None
 
     def setUp(self):
         self.conf = policy.Config()

--- a/starttls_policy_cli/tests/util_test.py
+++ b/starttls_policy_cli/tests/util_test.py
@@ -63,6 +63,12 @@ parametrize_over(TestEnforceUtil, TestEnforceUtil.parse_valid_date_test,
                     param("valid_string_date",
                           "2014-05-26T01:35:33+00:00",
                           datetime.datetime(2014, 5, 26, 1, 35, 33, tzinfo=tz.tzutc())),
+                    param("valid_string_date_notz",
+                          "2014-05-26T01:35:33",
+                          datetime.datetime(2014, 5, 26, 1, 35, 33, tzinfo=tz.tzutc())),
+                    param("valid_string_date_nocolon",
+                          "2014-05-26T01:35:33+0000",
+                          datetime.datetime(2014, 5, 26, 1, 35, 33, tzinfo=tz.tzutc())),
                  ])
 
 parametrize_over(TestEnforceUtil, TestEnforceUtil.is_expired_test,

--- a/starttls_policy_cli/util.py
+++ b/starttls_policy_cli/util.py
@@ -59,13 +59,17 @@ def parse_valid_date(date):
     interpreted as seconds since the epoch) or a formatted
     string that `dateutils.parser` can understand."""
     if isinstance(date, datetime.datetime):
-        return date
-    if isinstance(date, int):
-        return datetime.datetime.fromtimestamp(date, tz.tzutc())
-    try: # Fallback: try to parse a string-like
-        return parser.parse(date)
-    except (TypeError, ValueError):
-        raise ConfigError("Invalid date: {}".format(date))
+        result = date
+    elif isinstance(date, int):
+        result = datetime.datetime.fromtimestamp(date, tz.tzutc())
+    else:
+        try: # Fallback: try to parse a string-like
+            result = parser.parse(date)
+        except (TypeError, ValueError):
+            raise ConfigError("Invalid date: {}".format(date))
+    if result.tzinfo is None or result.tzinfo.utcoffset(result) is None:
+        result = result.replace(tzinfo=tz.tzutc())
+    return result
 
 def is_expired(exp):
     """ Checks if given expiration datetime is reached at this moment. """


### PR DESCRIPTION
Addresses issue #13 

Changes:
* util.parse_valid_date: Assume naive datetimes containing UTC time.
* Added testcases for naive dates
* Adjusted testcases which require indifferent form of data representation to pass. Probably we should improve json comparison in such tests in future.
* Removed output limitation for diff in config testcase (it's handy because json diff is too big to fit default limit).