### PR TITLE
Retire field validation & support in accordance with new spec

### DIFF
--- a/starttls_policy_cli/tests/policy_test.py
+++ b/starttls_policy_cli/tests/policy_test.py
@@ -18,8 +18,7 @@ test_json = '{\
             ".valid.example-recipient.com": {\
                 "min-tls-version": "TLSv1.1",\
                     "mode": "enforce",\
-                    "mxs": [".valid.example-recipient.com"],\
-                    "tls-report": "https://tls-rpt.example-recipient.org/api/report"\
+                    "mxs": [".valid.example-recipient.com"]\
             }\
         }\
     }'
@@ -176,29 +175,21 @@ class TestConfig(unittest.TestCase):
         conf.policies = {'valid': {'policy-alias': 'valid'}}
         self.assertEqual(conf.get_policy_for('valid').min_tls_version, 'TLSv1.2')
 
-    def test_set_pins_for_policy(self):
-        conf = policy.Config()
-        conf.pinsets = {'valid': 'lol a pin'}
-        with self.assertRaises(util.ConfigError):
-            conf.policies = {'invalid': {'pin': 'invalid'}}
-        conf.policies = {'valid': {'pin': 'valid'}}
-        self.assertEqual(conf.get_policy_for('valid').pin, 'valid')
-
     def test_iter_policies_aliased(self):
         conf = policy.Config()
-        conf.policy_aliases = {'valid': {'tls-report': 'https://tls.report'}}
+        conf.policy_aliases = {'valid': {'mode': 'enforce'}}
         conf.policies = {'valid1': {'policy-alias': 'valid'},
                          'valid2': {'policy-alias': 'valid'}}
         for val in conf:
-            self.assertEqual(conf[val].tls_report, 'https://tls.report')
+            self.assertEqual(conf[val].mode, 'enforce')
 
     def test_iter_policies(self):
         conf = policy.Config()
-        sample_policy = {'tls-report': 'https://tls.report'}
+        sample_policy = {'mode': 'enforce'}
         conf.policies = {'valid1': sample_policy,
                          'valid2': sample_policy}
         for val in conf:
-            self.assertEqual(conf[val].tls_report, 'https://tls.report')
+            self.assertEqual(conf[val].mode, 'enforce')
 
     def test_no_aliasing_in_alias(self):
         conf = policy.Config()
@@ -259,15 +250,6 @@ class TestPolicy(unittest.TestCase):
         p.mode = 'enforce'
         self.assertEqual(p.mode, 'enforce')
 
-    def test_pins_valid(self):
-        p = policy.Policy({}, pinsets={'valid': {}})
-        with self.assertRaises(util.ConfigError):
-            p.pin = 'invalid'
-        with self.assertRaises(util.ConfigError):
-            policy.Policy({'pin': 'invalid'}, pinsets={'valid': {}})
-        p.pin = 'valid'
-        self.assertEqual(p.pin, 'valid')
-
     def test_alias_valid(self):
         p = policy.Policy({}, aliases={'valid': self.sample_policy})
         with self.assertRaises(util.ConfigError):
@@ -276,21 +258,6 @@ class TestPolicy(unittest.TestCase):
             policy.Policy({'policy-alias': 'invalid'}, aliases={'valid': self.sample_policy})
         p.policy_alias = 'valid'
         self.assertEqual(p.policy_alias, 'valid')
-
-    def test_mta_sts(self):
-        p = policy.Policy({})
-        with self.assertRaises(util.ConfigError):
-            p.mta_sts = 'yes'
-        self.assertFalse(p.mta_sts)
-        p.mta_sts = True
-        self.assertTrue(p.mta_sts)
-
-    def test_tls_report(self):
-        p = policy.Policy({})
-        with self.assertRaises(util.ConfigError):
-            p.tls_report = False
-        p.tls_rpt = 'https://fake.reporting.endpoint'
-        self.assertEqual(p.tls_rpt, 'https://fake.reporting.endpoint')
 
     def test_mxs(self):
         p = policy.Policy({})

--- a/starttls_policy_cli/tests/testdata/bigger_test_config.json
+++ b/starttls_policy_cli/tests/testdata/bigger_test_config.json
@@ -3,7 +3,6 @@
   "author": "Electronic Frontier Foundation https://eff.org",
   "expires": "2015-08-01T12:00:00+08:00",
   "timestamp": 1401414363,
-  "pinsets": {},
   "policy-aliases": {},
   "policies": {
     "yahoodns.net": {
@@ -16,8 +15,7 @@
     },
     "google.com": {
       "mode": "testing",
-      "mxs": [".google.com"],
-      "report": ["https://google.com/post/reports/here"]
+      "mxs": [".google.com"]
     }
   }
 }

--- a/starttls_policy_cli/tests/testdata/config.json
+++ b/starttls_policy_cli/tests/testdata/config.json
@@ -3,18 +3,9 @@
   "timestamp": "2014-06-06T14:30:16+00:00",
   "author": "Electronic Frontier Foundation https://eff.org",
   "expires": "2014-06-06T14:30:16+00:00",
-  "pinsets": {
-    "eff": {
-      "static-spki-hashes": [
-        "sha1/5R0zeLx7EWRxqw6HRlgCRxNLHDo=",
-        "sha1/YlrkMlC6C4SJRZSVyRvnvoJ+8eM="
-      ]
-    }
-   },
   "policy-aliases": {
     "gmail": {
       "mode": "testing",
-      "report": ["https://google.com/post/reports/here"],
       "mxs": [".mail.google.com"]
     }
   },
@@ -25,7 +16,6 @@
      },
     "eff.org": {
       "mode": "enforce",
-      "pin": "eff",
       "mxs": [".eff.org"]
     },
     "gmail.com": {
@@ -33,7 +23,6 @@
     },
     "example.com": {
       "mode": "testing",
-      "mta-sts": true,
       "mxs": ["mail.example.com", ".example.net"]
     }
   }

--- a/starttls_policy_cli/tests/testdata/utf8.json
+++ b/starttls_policy_cli/tests/testdata/utf8.json
@@ -3,7 +3,6 @@
     "author": "电子前哨基金会",
     "expires": 1404677353,
     "timestamp": 1401093333,
-    "pinsets": {},
     "policy-aliases": {},
     "policies": {}
 }

--- a/starttls_policy_cli/util.py
+++ b/starttls_policy_cli/util.py
@@ -113,14 +113,7 @@ POLICY_SCHEMA = {
             'default': [],
             },
         # TODO (#50) Validate reporting endpoint as https: or mailto:
-        'tls-report': partial(enforce_type, six.string_types),
-        'pin': partial(enforce_type, six.string_types),
         'policy-alias': partial(enforce_type, six.string_types),
-        'mta-sts': partial(enforce_type, bool),
-}
-
-PINSET_SCHEMA = {
-    'static-spki-hashes': partial(enforce_list, partial(enforce_type, six.string_types))
 }
 
 CONFIG_SCHEMA = {
@@ -135,5 +128,4 @@ CONFIG_SCHEMA = {
             },
         'policies': partial(enforce_fields, partial(enforce_type, object)),
         'policy-aliases': partial(enforce_fields, partial(enforce_type, object)),
-        'pinsets': partial(enforce_fields, partial(enforce_type, object))
 }


### PR DESCRIPTION
This also fixes #19 (sort of).
In accordance with EFForg/starttls-everywhere#108.