### PR TITLE
Cleanup parser schema

### DIFF
--- a/starttls_policy_cli/policy.py
+++ b/starttls_policy_cli/policy.py
@@ -210,7 +210,6 @@ class PolicyNoAlias(Policy):
     @property
     def policy_alias(self):
         """ This type of policy can't be aliased. Returns None."""
-        pass
 
     @policy_alias.setter
     def policy_alias(self, value):
@@ -238,6 +237,7 @@ class Config(MergableConfig, collections.Mapping):
             yield domain
 
     def keys(self):
+        """ Returns iterable over policies even if this attribute is not set """
         if self.policies is None:
             return set([])
         return self.policies.keys()

--- a/starttls_policy_cli/tests/policy_test.py
+++ b/starttls_policy_cli/tests/policy_test.py
@@ -16,7 +16,6 @@ test_json = '{\
         "timestamp": "2014-05-26T01:35:33+0000",\
         "policies": {\
             ".valid.example-recipient.com": {\
-                "min-tls-version": "TLSv1.1",\
                     "mode": "enforce",\
                     "mxs": [".valid.example-recipient.com"]\
             }\
@@ -166,8 +165,8 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(util.ConfigError):
             policy.Config().policies = {'invalid': invalid_policy}
         conf = policy.Config()
-        conf.policies = {'valid': {}}
-        self.assertEqual(conf.get_policy_for('valid').min_tls_version, 'TLSv1.2')
+        conf.policies = {'valid': {'mxs': ['example.com']}}
+        self.assertEqual(conf.get_policy_for('valid').mxs, ['example.com'])
 
     def test_set_aliased_policy(self):
         conf = policy.Config()
@@ -175,7 +174,7 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(util.ConfigError):
             conf.policies = {'invalid': {'policy-alias': 'invalid'}}
         conf.policies = {'valid': {'policy-alias': 'valid'}}
-        self.assertEqual(conf.get_policy_for('valid').min_tls_version, 'TLSv1.2')
+        self.assertEqual(conf.get_policy_for('valid').mode, 'testing')
 
     def test_iter_policies_aliased(self):
         conf = policy.Config()
@@ -226,22 +225,9 @@ class TestPolicy(unittest.TestCase):
         self.assertFalse('eff.org' in new_conf.mxs)
         self.assertTrue('example.com' in new_conf.mxs)
 
-    def test_tls_version_default(self):
-        p = policy.Policy({})
-        self.assertEqual(p.min_tls_version, 'TLSv1.2')
-
     def test_mode_default(self):
         p = policy.Policy({})
         self.assertEqual(p.mode, 'testing')
-
-    def test_tls_version_valid(self):
-        with self.assertRaises(util.ConfigError):
-            policy.Policy({'min-tls-version': 'SSLv3'})
-        p = policy.Policy({})
-        with self.assertRaises(util.ConfigError):
-            p.min_tls_version = 'SSLv3'
-        p.min_tls_version = 'TLSv1.1'
-        self.assertEqual(p.min_tls_version, 'TLSv1.1')
 
     def test_mode_valid(self):
         p = policy.Policy({})

--- a/starttls_policy_cli/util.py
+++ b/starttls_policy_cli/util.py
@@ -103,20 +103,14 @@ TLS_VERSIONS = ('TLSv1', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3')
 ENFORCE_MODES = ('testing', 'enforce')
 
 POLICY_SCHEMA = {
-        'min-tls-version': {
-            'enforce': partial(enforce_in, TLS_VERSIONS),
-            'default': 'TLSv1.2',
-            },
         'mode': {
             'enforce': partial(enforce_in, ENFORCE_MODES),
             'default': 'testing',
             },
-        # TODO (#50) Validate mxs as FQDNs (using public suffix list)
         'mxs': {
             'enforce': partial(enforce_list, partial(enforce_type, six.string_types)),
             'default': [],
             },
-        # TODO (#50) Validate reporting endpoint as https: or mailto:
         'policy-alias': partial(enforce_type, six.string_types),
 }
 


### PR DESCRIPTION
Closes #18 

Removes min-tls-version since it is not part of spec anymore

```python
# TODO (#50) Validate reporting endpoint as https: or mailto:
```

-- removed since reporting endpoint is not part of spec anymore

```python
# TODO (#50) Validate mxs as FQDNs (using public suffix list)
```

-- removed because:

* Domain MX information is already authoritative
* Public suffix list is a list maintained mostly via manual submissions and is not good point of reference
* Presence of MX in policy list generally stronger than it absence. If MTA will have destination which matches policy (but not matches some of our sophisticated filters), then it's better to apply policy than not applying it.