### PR TITLE
Update README to reference pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,21 @@
 
 Run `pip install starttls_policy_cli` to install!
 
-#### Manually updating the policy list
-The below will fetch the remote policy list from `https://dl.eff.org/starttls-everywhere/policy.json` and verify the corresponding signature:
-```
-starttls-policy-cli --update-only [--policy-dir /path/to/dir]
-```
+### Generating a configuration file
 
-#### Generating a configuration file
 `starttls-policy-cli --generate <MTA> [--policy-dir /path/to/dir]` will generate a configuration file corresponding to the TLS policy list and provide instructions for installing the file.
 
 We currently only support Postfix, but contributions are welcome!
+
+#### Early adopter mode
+
+The flag `--early-adopter` (or `-e`) processes all "testing" domains in the policy list the same way as domains in "enforce" mode, effectively requiring strong TLS for all domains. This mode is useful for participating in tests of recently added domains and stronger security hardening at the cost of increased probability of delivery degradation.
 
 ## Development
 
 We recommend using `virtualenv` and `pip` to install and run `starttls-policy-cli` while developing. To get set up:
 ```
-virtualenv --no-site-packages --setuptools venv --python python3.6
-source ./venv/bin/activate
+virtualenv --no-site-packages --setuptools starttls_venv --python python3.6
+source ./starttls_venv/bin/activate
 pip install -e .
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # starttls-policy-cli Python package
 
-Run `pip install starttls_policy_cli` to install!
+Run `pip install starttls-policy-cli` to install!
 
 ### Generating a configuration file
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 # starttls-policy-cli Python package
 
-## Package API
-
-## Run CLI
-Since this is a developer alpha, we recommend using `virtualenv` and `pip` to
-install and run `starttls-policy-cli`. To get set up:
-```
-virtualenv --no-site-packages --setuptools venv --python python2.7
-source ./venv/bin/activate
-pip install starttls-policy-cli
-```
+Run `pip install starttls_policy_cli` to install!
 
 #### Manually updating the policy list
 The below will fetch the remote policy list from `https://dl.eff.org/starttls-everywhere/policy.json` and verify the corresponding signature:
@@ -22,3 +13,11 @@ starttls-policy-cli --update-only [--policy-dir /path/to/dir]
 
 We currently only support Postfix, but contributions are welcome!
 
+## Development
+
+We recommend using `virtualenv` and `pip` to install and run `starttls-policy-cli` while developing. To get set up:
+```
+virtualenv --no-site-packages --setuptools venv --python python3.6
+source ./venv/bin/activate
+pip install -e .
+```


### PR DESCRIPTION
Noticed that the usage README is a bit out-of-date. This should fix it!